### PR TITLE
Changed return array when creating an event

### DIFF
--- a/src/GoogleCalendar.php
+++ b/src/GoogleCalendar.php
@@ -330,7 +330,7 @@ class GoogleCalendar
         // Insert new event
         $event = $service->events->insert($request->calendarId, $event);
 
-        return array('message' => 'success' , 'htmlLink' => $event->htmlLink);
+        return array('message' => 'success' , 'event' => $event);
 
     }
 


### PR DESCRIPTION
Return the entire created event object back to the developer, that way he can do anything he want with the info, like retrieving the ID and also the htmlLink.